### PR TITLE
Updated Heading color of Service and Support

### DIFF
--- a/src/Components/ServicesPage/ServiceHead.js
+++ b/src/Components/ServicesPage/ServiceHead.js
@@ -4,7 +4,7 @@ const ServiceHead = () => {
   return (
    <div>
      
-      <h1 className=' text-5xl text-25414E font-bold  '> SERVICE AND SUPPORT </h1>
+      <h1 className=' text-5xl text-25414E font-bold text-blue-950  '> SERVICE AND SUPPORT </h1>
       <p className='  text-lg font-thick italic mt-4  '>How can we help you today?</p>
     </div>
   );

--- a/src/Components/ServicesPage/ServiceLogo.js
+++ b/src/Components/ServicesPage/ServiceLogo.js
@@ -2,7 +2,7 @@ import React from 'react'
 import Service from "../../Assets/Service.png.png";
 const ServiceLogo = () => {
   return (
-  <div className="items-center ml-9 mt-2 ">
+  <div className="items-center ml-9 mt-1">
       <img src={Service} alt="Service" className="h-12 w-12" />
     </div>
   )


### PR DESCRIPTION
There was a change in text colour of heading of service and support and alignment of logo alongside so i have completed it 

<img width="799" height="75" alt="image" src="https://github.com/user-attachments/assets/9974bc99-c680-42ce-b3f1-a4464d18327b" />

Hi @Raktim-Koner , BUGFIX/rohit-027 please review this PR and Merge it >>>